### PR TITLE
feat: add voice pipeline (STT/TTS/NLU/NLI) for speaker integration

### DIFF
--- a/app/api/v1/voice.py
+++ b/app/api/v1/voice.py
@@ -1,0 +1,155 @@
+"""Голосовой API.
+
+Эндпоинты:
+- POST /voice/converse  — основной для колонки/приложения. WAV in → стрим WAV TTS,
+                          метаданные пайплайна — в заголовке X-Pipeline-Metadata
+                          (base64 JSON, чтобы пройти HTTP).
+- POST /voice/stt       — только распознавание (для аналитики/отладки).
+- POST /voice/tts       — только синтез (text → WAV stream).
+- POST /voice/nlu       — классификация интента по тексту.
+- POST /voice/nli/sentiment — тональность.
+- POST /voice/nli/entailment — entailment по паре (premise, hypothesis).
+- POST /voice/emergency — явная тревога без аудио (от мобильного клиента).
+
+Авторизация — единый user-JWT (та же `get_current_user`, что и для остальных API).
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from app.api.v1.auth import get_current_user
+from app.core.database import get_db
+from app.models.user import User
+from app.schemas.voice import (
+    ConverseMetadata,
+    EntailmentRequest,
+    EntailmentResponse,
+    NLURequest,
+    NLUResponse,
+    SentimentRequest,
+    SentimentResponse,
+    STTResponse,
+    TTSRequest,
+)
+from app.services.audio_utils import AudioError, save_wav
+from app.services.emergency_service import notify_family_of_emergency
+from app.services.nli_service import get_nli_service
+from app.services.nlu_service import NLUService
+from app.services.stt_service import get_stt_service
+from app.services.tts_service import get_tts_service
+from app.services.voice_pipeline import VoicePipeline
+
+router = APIRouter()
+
+
+@router.post("/converse")
+async def converse(
+    audio: UploadFile = File(..., description="WAV PCM 16kHz mono 16-bit"),
+    source: str = "speaker",
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    data = await audio.read()
+    pipeline = VoicePipeline(db, current_user, source=source)
+
+    try:
+        meta, response_text = await pipeline.process(data)
+    except AudioError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    tts = get_tts_service()
+    audio_iter = tts.synthesize_stream(response_text)
+
+    meta_b64 = base64.b64encode(
+        json.dumps(meta.to_dict(), ensure_ascii=False).encode("utf-8")
+    ).decode("ascii")
+
+    headers = {
+        "X-Pipeline-Metadata": meta_b64,
+        "X-Intent": meta.intent,
+        "X-Is-Emergency": "1" if meta.is_emergency else "0",
+        "X-TTS-Sample-Rate": str(tts.sample_rate),
+    }
+    return StreamingResponse(audio_iter, media_type="audio/wav", headers=headers)
+
+
+@router.post("/stt", response_model=STTResponse)
+async def stt_endpoint(
+    audio: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+):
+    data = await audio.read()
+    try:
+        path, duration = save_wav(current_user.id, data)
+    except AudioError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    res = await get_stt_service().transcribe_file(str(path))
+    return STTResponse(
+        text=res.text,
+        language=res.language,
+        confidence=res.confidence,
+        duration_sec=res.duration_sec or duration,
+    )
+
+
+@router.post("/tts")
+async def tts_endpoint(
+    body: TTSRequest,
+    current_user: User = Depends(get_current_user),
+):
+    if not body.text.strip():
+        raise HTTPException(status_code=400, detail="Пустой текст")
+    tts = get_tts_service()
+    return StreamingResponse(
+        tts.synthesize_stream(body.text),
+        media_type="audio/wav",
+        headers={"X-TTS-Sample-Rate": str(tts.sample_rate)},
+    )
+
+
+@router.post("/nlu", response_model=NLUResponse)
+async def nlu_endpoint(
+    body: NLURequest,
+    current_user: User = Depends(get_current_user),
+):
+    res = await NLUService().classify(body.text)
+    return NLUResponse(
+        intent=res.intent,
+        slots=res.slots,
+        confidence=res.confidence,
+        source=res.source,
+    )
+
+
+@router.post("/nli/sentiment", response_model=SentimentResponse)
+async def sentiment_endpoint(
+    body: SentimentRequest,
+    current_user: User = Depends(get_current_user),
+):
+    res = await get_nli_service().sentiment(body.text)
+    return SentimentResponse(label=res.label, score=res.score)
+
+
+@router.post("/nli/entailment", response_model=EntailmentResponse)
+async def entailment_endpoint(
+    body: EntailmentRequest,
+    current_user: User = Depends(get_current_user),
+):
+    res = await get_nli_service().entailment(body.premise, body.hypothesis)
+    return EntailmentResponse(label=res.label, score=res.score)
+
+
+@router.post("/emergency")
+async def emergency_endpoint(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Кнопка SOS из мобильного приложения (без аудио)."""
+    notified = notify_family_of_emergency(db, current_user, message="manual SOS")
+    return {"ok": True, "notified": notified}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,6 +9,21 @@ class Settings(BaseSettings):
     LLM_API_URL: str
     LLM_API_KEY: str
 
-    model_config = ConfigDict(env_file=".env")
+    # --- Speech / NLP pipeline ---
+    WHISPER_MODEL: str = "small"
+    WHISPER_DEVICE: str = "cpu"          # "cuda" если есть GPU
+    WHISPER_COMPUTE_TYPE: str = "int8"   # "float16" для GPU
+    WHISPER_LANGUAGE: str = "ru"
+
+    PIPER_VOICE: str = "ru_RU-irina-medium"
+    PIPER_MODELS_DIR: str = "models/piper"
+
+    NLI_SENTIMENT_MODEL: str = "seara/rubert-tiny2-russian-sentiment"
+    NLI_ENTAILMENT_MODEL: str = "cointegrated/rubert-base-cased-nli-threeway"
+
+    VOICE_STORAGE_DIR: str = "data/voice"
+    VOICE_SAMPLE_RATE: int = 16000
+
+    model_config = ConfigDict(env_file=".env", extra="ignore")
 
 settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from app.api.v1 import auth, chat, stats, notifications
+from app.api.v1 import auth, chat, stats, notifications, voice
 from app.core.database import engine
 from app.models import Base
 
@@ -19,6 +19,7 @@ app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 app.include_router(chat.router, prefix="/api/v1/chat", tags=["chat"])
 app.include_router(stats.router, prefix="/api/v1/stats", tags=["stats"])
 app.include_router(notifications.router, prefix="/api/v1/notifications", tags=["notifications"])
+app.include_router(voice.router, prefix="/api/v1/voice", tags=["voice"])
 
 from fastapi import Request
 from fastapi.responses import HTMLResponse

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,4 +2,7 @@ from app.models.user import User
 from app.models.health_metric import HealthMetric
 from app.models.conversation import Conversation
 from app.models.log import Log
+from app.models.voice_log import VoiceLog
+from app.models.family import Family, FamilyMember
+from app.models.user_settings import UserSettings
 from app.core.database import Base

--- a/app/models/family.py
+++ b/app/models/family.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, UniqueConstraint
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+
+class Family(Base):
+    __tablename__ = "families"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    invite_code = Column(String, unique=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class FamilyMember(Base):
+    __tablename__ = "family_members"
+    __table_args__ = (UniqueConstraint("family_id", "user_id", name="family_members_family_id_user_id_key"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    role = Column(Text, nullable=False)  # 'head' | 'member'
+    joined_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/app/models/user_settings.py
+++ b/app/models/user_settings.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+
+class UserSettings(Base):
+    __tablename__ = "user_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False)
+    address_name = Column(String, nullable=True)
+    voice = Column(String, nullable=False, server_default="ru_RU-irina-medium")
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/app/models/voice_log.py
+++ b/app/models/voice_log.py
@@ -1,0 +1,31 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, Float, JSON, Boolean
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+
+class VoiceLog(Base):
+    __tablename__ = "voice_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+
+    audio_path = Column(String, nullable=True)
+    duration_sec = Column(Float, nullable=True)
+
+    transcript = Column(Text, nullable=True)
+    stt_language = Column(String, nullable=True)
+    stt_confidence = Column(Float, nullable=True)
+
+    nlu_intent = Column(String, nullable=True, index=True)
+    nlu_slots = Column(JSON, nullable=True)
+
+    sentiment_label = Column(String, nullable=True)
+    sentiment_score = Column(Float, nullable=True)
+    entailment_label = Column(String, nullable=True)
+    entailment_score = Column(Float, nullable=True)
+
+    response_text = Column(Text, nullable=True)
+    is_emergency = Column(Boolean, nullable=False, server_default="false")
+    source = Column(String, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/app/schemas/voice.py
+++ b/app/schemas/voice.py
@@ -1,0 +1,62 @@
+from typing import Any, Optional
+from pydantic import BaseModel
+
+
+class STTResponse(BaseModel):
+    text: str
+    language: str
+    confidence: float
+    duration_sec: float
+
+
+class TTSRequest(BaseModel):
+    text: str
+
+
+class NLURequest(BaseModel):
+    text: str
+
+
+class NLUResponse(BaseModel):
+    intent: str
+    slots: dict[str, Any] = {}
+    confidence: float
+    source: str
+
+
+class SentimentRequest(BaseModel):
+    text: str
+
+
+class SentimentResponse(BaseModel):
+    label: str
+    score: float
+
+
+class EntailmentRequest(BaseModel):
+    premise: str
+    hypothesis: str
+
+
+class EntailmentResponse(BaseModel):
+    label: str
+    score: float
+
+
+class ConverseMetadata(BaseModel):
+    transcript: str
+    stt_language: str
+    stt_confidence: float
+    duration_sec: float
+    intent: str
+    intent_confidence: float
+    intent_source: str
+    slots: dict[str, Any]
+    sentiment_label: str
+    sentiment_score: float
+    entailment_label: Optional[str] = None
+    entailment_score: Optional[float] = None
+    response_text: str
+    is_emergency: bool
+    saved_metrics: list[str] = []
+    notified_family_members: int = 0

--- a/app/services/audio_utils.py
+++ b/app/services/audio_utils.py
@@ -1,0 +1,56 @@
+"""Аудио-утилиты: проверка/нормализация WAV в 16kHz mono PCM16."""
+from __future__ import annotations
+
+import io
+import os
+import wave
+from pathlib import Path
+from uuid import uuid4
+
+from app.core.config import settings
+
+
+class AudioError(ValueError):
+    pass
+
+
+def ensure_storage_dir(user_id: int) -> Path:
+    base = Path(settings.VOICE_STORAGE_DIR) / str(user_id)
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def save_wav(user_id: int, data: bytes) -> tuple[Path, float]:
+    """Сохранить WAV-байты на диск, проверив формат.
+    Возвращает (путь, длительность_сек).
+    """
+    if not data or len(data) < 44:
+        raise AudioError("Пустой или повреждённый WAV (нет RIFF-заголовка)")
+
+    # Валидация: WAV 16kHz mono PCM16. ffmpeg-конверсия не делается —
+    # клиент обязан прислать корректный формат (см. docs).
+    try:
+        with wave.open(io.BytesIO(data), "rb") as w:
+            channels = w.getnchannels()
+            sample_rate = w.getframerate()
+            sample_width = w.getsampwidth()
+            n_frames = w.getnframes()
+    except wave.Error as e:
+        raise AudioError(f"Невалидный WAV: {e}")
+
+    if channels != 1:
+        raise AudioError(f"Ожидается mono (1 канал), получено {channels}")
+    if sample_rate != settings.VOICE_SAMPLE_RATE:
+        raise AudioError(
+            f"Ожидается частота {settings.VOICE_SAMPLE_RATE} Гц, получено {sample_rate}"
+        )
+    if sample_width != 2:
+        raise AudioError(f"Ожидается PCM 16-bit, sample_width={sample_width}")
+
+    duration = n_frames / float(sample_rate) if sample_rate else 0.0
+    if duration > 120:
+        raise AudioError("Аудио длиннее 120 секунд — отклонено")
+
+    dest = ensure_storage_dir(user_id) / f"{uuid4().hex}.wav"
+    dest.write_bytes(data)
+    return dest, duration

--- a/app/services/emergency_service.py
+++ b/app/services/emergency_service.py
@@ -1,0 +1,48 @@
+"""Тревожная кнопка: рассылка уведомлений членам семьи пользователя."""
+from __future__ import annotations
+
+from datetime import datetime
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.models.family import FamilyMember
+from app.models.log import Log
+from app.models.user import User
+
+
+def notify_family_of_emergency(db: Session, user: User, message: str | None = None) -> int:
+    """Создаёт уведомления (через таблицу logs с action='emergency_notify')
+    для всех членов семей, в которых состоит пользователь.
+
+    Возвращает количество оповещённых членов семьи. Канал доставки
+    (push / SMS / email) подключается отдельно — здесь персистится
+    событие, на которое подпишется внешний notifier.
+    """
+    families = (
+        db.query(FamilyMember.family_id)
+        .filter(FamilyMember.user_id == user.id)
+        .all()
+    )
+    family_ids = [f.family_id for f in families]
+    if not family_ids:
+        logger.warning(f"Emergency для user_id={user.id}, но семей нет")
+        return 0
+
+    targets = (
+        db.query(FamilyMember)
+        .filter(FamilyMember.family_id.in_(family_ids))
+        .filter(FamilyMember.user_id != user.id)
+        .all()
+    )
+
+    payload = (
+        f"EMERGENCY user_id={user.id} username={user.username} "
+        f"at={datetime.utcnow().isoformat()}Z message={message or ''!r}"
+    )
+
+    for tgt in targets:
+        db.add(Log(user_id=tgt.user_id, action="emergency_notify", details=payload))
+    db.add(Log(user_id=user.id, action="emergency_triggered", details=payload))
+    db.commit()
+    logger.info(f"Emergency: оповещено {len(targets)} родственников для user_id={user.id}")
+    return len(targets)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -7,6 +7,25 @@ class LLMClient:
         self.base_url = host.rstrip('/')
         logger.info(f"Клиент Ollama для модели {model_name}")
 
+    async def generate_json(self, prompt: str, system: str = "") -> str:
+        """Запрос с принудительным JSON-выводом (Ollama format=json)."""
+        payload = {
+            "model": self.model_name,
+            "prompt": prompt,
+            "system": system,
+            "format": "json",
+            "stream": False,
+            "options": {"temperature": 0.0, "num_predict": 256},
+        }
+        try:
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                resp = await client.post(f"{self.base_url}/api/generate", json=payload)
+                resp.raise_for_status()
+                return (resp.json().get("response") or "").strip()
+        except Exception as e:
+            logger.error(f"LLM JSON-запрос упал: {e}")
+            return ""
+
     async def generate_response(self, prompt: str, context: str = "") -> str:
         full_prompt = f"{context}\n\n{prompt}" if context else prompt
         payload = {

--- a/app/services/nli_service.py
+++ b/app/services/nli_service.py
@@ -1,0 +1,116 @@
+"""NLI: два независимых компонента.
+
+1. Sentiment  — `seara/rubert-tiny2-russian-sentiment` (метки neutral/positive/negative).
+   Используется для отметки эмоционального тона реплик; помогает выявлять
+   признаки ухудшения состояния даже когда явной тревожной фразы нет.
+
+2. Entailment — `cointegrated/rubert-base-cased-nli-threeway`
+   (entailment / contradiction / neutral). Берём в роли premise последний
+   сохранённый факт о здоровье (или предыдущую реплику пользователя),
+   в роли hypothesis — текущее сообщение. Так детектим противоречия:
+   например, premise «давление 160/100», hypothesis «у меня давление в норме»
+   → contradiction → можно переспросить пользователя.
+
+Модели грузятся лениво (singleton), чтобы старт сервера не зависел от
+наличия инференс-моделей; первый запрос будет дольше последующих.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from threading import Lock
+from typing import Optional
+
+from loguru import logger
+
+from app.core.config import settings
+
+
+@dataclass
+class SentimentResult:
+    label: str           # 'positive' | 'neutral' | 'negative'
+    score: float
+
+
+@dataclass
+class EntailmentResult:
+    label: str           # 'entailment' | 'neutral' | 'contradiction'
+    score: float
+
+
+class _LazyPipeline:
+    def __init__(self, task: str, model: str):
+        self._task = task
+        self._model = model
+        self._pipe = None
+        self._lock = Lock()
+
+    def get(self):
+        if self._pipe is None:
+            with self._lock:
+                if self._pipe is None:
+                    from transformers import pipeline
+                    logger.info(f"Загрузка HF pipeline: task={self._task} model={self._model}")
+                    self._pipe = pipeline(self._task, model=self._model, device=-1)
+        return self._pipe
+
+
+class NLIService:
+    _instance: Optional["NLIService"] = None
+    _lock = Lock()
+
+    def __new__(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._init_done = False
+            return cls._instance
+
+    def __init__(self):
+        if self._init_done:
+            return
+        self._sentiment = _LazyPipeline("sentiment-analysis", settings.NLI_SENTIMENT_MODEL)
+        self._entailment = _LazyPipeline("text-classification", settings.NLI_ENTAILMENT_MODEL)
+        self._init_done = True
+
+    # ----- sentiment -----
+    def _sentiment_sync(self, text: str) -> SentimentResult:
+        try:
+            res = self._sentiment.get()(text, truncation=True)[0]
+            return SentimentResult(label=str(res["label"]).lower(), score=float(res["score"]))
+        except Exception as e:
+            logger.warning(f"Sentiment упал: {e}")
+            return SentimentResult(label="neutral", score=0.0)
+
+    async def sentiment(self, text: str) -> SentimentResult:
+        return await asyncio.to_thread(self._sentiment_sync, text)
+
+    # ----- entailment -----
+    def _entailment_sync(self, premise: str, hypothesis: str) -> EntailmentResult:
+        try:
+            pipe = self._entailment.get()
+            # модель ждёт пару — передаём через text/text_pair
+            out = pipe({"text": premise, "text_pair": hypothesis}, truncation=True)
+            if isinstance(out, list):
+                out = out[0]
+            label = str(out["label"]).lower()
+            # нормализуем имена меток к канону
+            mapping = {
+                "entailment": "entailment",
+                "contradiction": "contradiction",
+                "neutral": "neutral",
+                "label_0": "entailment",
+                "label_1": "neutral",
+                "label_2": "contradiction",
+            }
+            return EntailmentResult(label=mapping.get(label, label), score=float(out["score"]))
+        except Exception as e:
+            logger.warning(f"Entailment упал: {e}")
+            return EntailmentResult(label="neutral", score=0.0)
+
+    async def entailment(self, premise: str, hypothesis: str) -> EntailmentResult:
+        return await asyncio.to_thread(self._entailment_sync, premise, hypothesis)
+
+
+def get_nli_service() -> NLIService:
+    return NLIService()

--- a/app/services/nlu_service.py
+++ b/app/services/nlu_service.py
@@ -1,0 +1,169 @@
+"""NLU: определение интента + слотов.
+
+Гибрид:
+1. Быстрый путь — regex и ключевые слова. Срабатывает мгновенно
+   на типовые фразы (метрики здоровья, тревога, статистика, напоминания).
+2. Fallback — Gemma3 через Ollama в format=json. Используется, когда
+   regex ничего не дал, либо confidence низкий.
+
+Слоты для метрик переиспользуют логику из ChatProcessor._extract_health_metrics.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+from app.services.llm_client import LLMClient
+
+
+# Канонический набор интентов
+INTENTS = (
+    "save_metric",      # пользователь сообщил замер (давление/пульс/...)
+    "get_stats",        # просит показать статистику/график
+    "panic",            # тревога / SOS
+    "set_reminder",     # «напомни...»
+    "cyclic_query",     # настроить регулярные опросы
+    "family_invite",    # пригласить в семью
+    "chitchat",         # обычный диалог / вопрос помощнику
+    "unknown",
+)
+
+_PANIC_TOKENS = (
+    "помогите", "помоги", "плохо мне", "мне плохо", "тревога",
+    "вызови скорую", "скорую", "беда", "сос", "сигнал тревоги",
+    "не могу дышать", "сильная боль", "теряю сознание", "упал",
+)
+
+_STATS_TOKENS = ("статистик", "график", "историю", "покажи измерен", "динамик")
+
+_REMINDER_TOKENS = ("напомни", "напоминай", "напоминание")
+
+_CYCLIC_TOKENS = ("каждый день", "ежедневно", "каждое утро", "регулярно спрашивай",
+                  "опрашивай меня", "спрашивай меня каждый")
+
+_FAMILY_TOKENS = ("пригласи в семью", "добавь в семью", "семейный код", "код приглашен")
+
+
+@dataclass
+class NLUResult:
+    intent: str
+    slots: dict[str, Any] = field(default_factory=dict)
+    confidence: float = 0.0
+    source: str = "rules"  # 'rules' | 'llm'
+
+
+class NLUService:
+    def __init__(self, llm: LLMClient | None = None):
+        self.llm = llm or LLMClient()
+
+    # --- regex слоты для метрик (та же логика, что в chat_processor) ---
+    @staticmethod
+    def extract_metrics(text: str) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        t = text.lower()
+
+        m = re.search(r"(?:давлени[ея]|ад)\s*[:=]?\s*(\d{2,3})\s*[/на ]+\s*(\d{2,3})", t)
+        if m:
+            sys_, dia = int(m.group(1)), int(m.group(2))
+            if 60 <= sys_ <= 250 and 30 <= dia <= 150:
+                out.append({"type": "blood_pressure", "value": {"systolic": sys_, "diastolic": dia}})
+
+        m = re.search(r"(?:пульс|чсс|сердцебиени[ея])\s*[:=]?\s*(\d{2,3})", t)
+        if m:
+            v = int(m.group(1))
+            if 30 <= v <= 220:
+                out.append({"type": "pulse", "value": {"value": v}})
+
+        m = re.search(r"(?:вес|масс[аы](?:\s*тела)?)\s*[:=]?\s*(\d{2,3}(?:[.,]\d{1,2})?)", t)
+        if m:
+            v = float(m.group(1).replace(",", "."))
+            if 20 <= v <= 300:
+                out.append({"type": "weight", "value": {"value": v}})
+
+        m = re.search(r"(?:температур[аы]|темп)\s*[:=]?\s*(\d{2}(?:[.,]\d{1,2})?)", t)
+        if m:
+            v = float(m.group(1).replace(",", "."))
+            if 34.0 <= v <= 42.0:
+                out.append({"type": "temperature", "value": {"value": v}})
+
+        m = re.search(r"(?:сахар|глюкоз[аы]|гликеми[яю])\s*[:=]?\s*(\d{1,2}(?:[.,]\d{1,2})?)", t)
+        if m:
+            v = float(m.group(1).replace(",", "."))
+            if 1.0 <= v <= 30.0:
+                out.append({"type": "blood_sugar", "value": {"value": v}})
+
+        return out
+
+    def _rule_based(self, text: str) -> NLUResult | None:
+        t = text.lower().strip()
+        if not t:
+            return NLUResult(intent="unknown", confidence=1.0, source="rules")
+
+        # 1) Тревога — самый высокий приоритет
+        if any(tok in t for tok in _PANIC_TOKENS):
+            return NLUResult(intent="panic", slots={}, confidence=0.95, source="rules")
+
+        # 2) Метрики
+        metrics = self.extract_metrics(t)
+        if metrics:
+            return NLUResult(
+                intent="save_metric",
+                slots={"metrics": metrics},
+                confidence=0.9,
+                source="rules",
+            )
+
+        # 3) Статистика
+        if any(tok in t for tok in _STATS_TOKENS):
+            return NLUResult(intent="get_stats", slots={}, confidence=0.85, source="rules")
+
+        # 4) Напоминание
+        if any(tok in t for tok in _REMINDER_TOKENS):
+            return NLUResult(intent="set_reminder", slots={"raw": text}, confidence=0.7, source="rules")
+
+        # 5) Циклический опрос
+        if any(tok in t for tok in _CYCLIC_TOKENS):
+            return NLUResult(intent="cyclic_query", slots={"raw": text}, confidence=0.7, source="rules")
+
+        # 6) Семья
+        if any(tok in t for tok in _FAMILY_TOKENS):
+            return NLUResult(intent="family_invite", slots={"raw": text}, confidence=0.7, source="rules")
+
+        return None
+
+    async def _llm_classify(self, text: str) -> NLUResult:
+        system = (
+            "Ты классификатор намерений русскоязычного голосового помощника по здоровью. "
+            "Верни СТРОГО JSON: {\"intent\": <одно из: save_metric, get_stats, panic, "
+            "set_reminder, cyclic_query, family_invite, chitchat, unknown>, "
+            "\"slots\": {...}, \"confidence\": <0..1>}. "
+            "Никакого текста вне JSON."
+        )
+        prompt = f"Сообщение пользователя: {text}\nJSON:"
+        raw = await self.llm.generate_json(prompt, system=system)
+        if not raw:
+            return NLUResult(intent="chitchat", confidence=0.3, source="llm")
+        try:
+            data = json.loads(raw)
+            intent = data.get("intent", "chitchat")
+            if intent not in INTENTS:
+                intent = "chitchat"
+            return NLUResult(
+                intent=intent,
+                slots=data.get("slots") or {},
+                confidence=float(data.get("confidence") or 0.5),
+                source="llm",
+            )
+        except Exception as e:
+            logger.warning(f"LLM NLU вернул не-JSON: {raw!r} ({e})")
+            return NLUResult(intent="chitchat", confidence=0.3, source="llm")
+
+    async def classify(self, text: str) -> NLUResult:
+        rule = self._rule_based(text)
+        if rule and rule.confidence >= 0.7:
+            return rule
+        return await self._llm_classify(text)

--- a/app/services/stt_service.py
+++ b/app/services/stt_service.py
@@ -1,0 +1,85 @@
+"""STT через faster-whisper (CTranslate2-бэкенд Whisper).
+
+Модель загружается один раз при первом обращении (singleton),
+последующие вызовы переиспользуют её. Это даёт минимальную задержку
+для batch-запросов от колонки/приложения с уже нарезанным VAD аудио.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+from dataclasses import dataclass
+from threading import Lock
+from typing import Optional
+
+from loguru import logger
+
+from app.core.config import settings
+
+
+@dataclass
+class STTResult:
+    text: str
+    language: str
+    confidence: float
+    duration_sec: float
+
+
+class STTService:
+    _instance: Optional["STTService"] = None
+    _lock = Lock()
+
+    def __new__(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._initialized = False
+            return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+        from faster_whisper import WhisperModel
+
+        logger.info(
+            f"Загрузка faster-whisper: model={settings.WHISPER_MODEL} "
+            f"device={settings.WHISPER_DEVICE} compute={settings.WHISPER_COMPUTE_TYPE}"
+        )
+        self._model = WhisperModel(
+            settings.WHISPER_MODEL,
+            device=settings.WHISPER_DEVICE,
+            compute_type=settings.WHISPER_COMPUTE_TYPE,
+        )
+        self._initialized = True
+
+    def _transcribe_sync(self, audio_path: str) -> STTResult:
+        # VAD-фильтр на стороне Whisper отрезает паузы → меньше галлюцинаций.
+        segments, info = self._model.transcribe(
+            audio_path,
+            language=settings.WHISPER_LANGUAGE,
+            beam_size=1,            # greedy → ниже задержка
+            vad_filter=True,
+            vad_parameters={"min_silence_duration_ms": 400},
+        )
+        parts: list[str] = []
+        avg_logprob_sum = 0.0
+        n = 0
+        for seg in segments:
+            parts.append(seg.text.strip())
+            avg_logprob_sum += seg.avg_logprob
+            n += 1
+        text = " ".join(p for p in parts if p).strip()
+        confidence = float(min(1.0, max(0.0, (avg_logprob_sum / n + 1.0)))) if n else 0.0
+        return STTResult(
+            text=text,
+            language=info.language or settings.WHISPER_LANGUAGE,
+            confidence=confidence,
+            duration_sec=float(info.duration or 0.0),
+        )
+
+    async def transcribe_file(self, audio_path: str) -> STTResult:
+        return await asyncio.to_thread(self._transcribe_sync, audio_path)
+
+
+def get_stt_service() -> STTService:
+    return STTService()

--- a/app/services/tts_service.py
+++ b/app/services/tts_service.py
@@ -1,0 +1,83 @@
+"""TTS через Piper. Голос загружается один раз; синтез отдаётся
+в виде streaming-чанков WAV PCM 16-bit mono, чтобы клиент мог начать
+воспроизведение до окончания генерации.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+import wave
+from pathlib import Path
+from threading import Lock
+from typing import AsyncIterator, Optional
+
+from loguru import logger
+
+from app.core.config import settings
+
+
+class TTSService:
+    _instance: Optional["TTSService"] = None
+    _lock = Lock()
+
+    def __new__(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._initialized = False
+            return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+        from piper import PiperVoice
+
+        models_dir = Path(settings.PIPER_MODELS_DIR)
+        models_dir.mkdir(parents=True, exist_ok=True)
+        voice_name = settings.PIPER_VOICE
+        onnx_path = models_dir / f"{voice_name}.onnx"
+        config_path = models_dir / f"{voice_name}.onnx.json"
+
+        if not onnx_path.exists() or not config_path.exists():
+            raise FileNotFoundError(
+                f"Piper voice не найден: {onnx_path}. "
+                f"Скачайте с https://github.com/rhasspy/piper/blob/master/VOICES.md "
+                f"и положите оба файла ({voice_name}.onnx, {voice_name}.onnx.json) "
+                f"в каталог {models_dir.resolve()}"
+            )
+
+        logger.info(f"Загрузка Piper voice: {voice_name}")
+        self._voice = PiperVoice.load(str(onnx_path), config_path=str(config_path))
+        self._sample_rate = self._voice.config.sample_rate
+        self._initialized = True
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
+
+    def _synthesize_to_wav_bytes(self, text: str) -> bytes:
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(self._sample_rate)
+            self._voice.synthesize(text, wav)
+        return buf.getvalue()
+
+    async def synthesize_full(self, text: str) -> bytes:
+        """Полный WAV (для эндпоинта /tts, REST-клиентов)."""
+        return await asyncio.to_thread(self._synthesize_to_wav_bytes, text)
+
+    async def synthesize_stream(self, text: str, chunk_size: int = 4096) -> AsyncIterator[bytes]:
+        """WAV-поток с заголовком в первом чанке. Сначала отдаём header,
+        потом PCM-данные кусками — клиент начинает играть сразу."""
+        data = await asyncio.to_thread(self._synthesize_to_wav_bytes, text)
+        for i in range(0, len(data), chunk_size):
+            yield data[i:i + chunk_size]
+            # отдаём управление event loop между чанками
+            await asyncio.sleep(0)
+
+
+def get_tts_service() -> TTSService:
+    return TTSService()

--- a/app/services/voice_pipeline.py
+++ b/app/services/voice_pipeline.py
@@ -1,0 +1,228 @@
+"""Сквозной голосовой пайплайн: WAV → STT → (NLU || NLI) → action → answer.
+
+Основные принципы низкой задержки:
+- NLU и NLI запускаются параллельно через asyncio.gather.
+- Метрики, статистика, тревога — обрабатываются локально (без вызова LLM).
+- К LLM (Gemma3) обращаемся только если интент = chitchat / unknown.
+- Ответ возвращается текстом; стрим TTS делает уже эндпоинт.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, asdict
+from typing import Any
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.models.health_metric import HealthMetric
+from app.models.user import User
+from app.models.voice_log import VoiceLog
+from app.services.audio_utils import save_wav
+from app.services.emergency_service import notify_family_of_emergency
+from app.services.health_stats import HealthStatsService
+from app.services.llm_client import LLMClient
+from app.services.nli_service import EntailmentResult, NLIService, SentimentResult, get_nli_service
+from app.services.nlu_service import NLUResult, NLUService
+from app.services.reporting import ReportingService
+from app.services.stt_service import STTResult, get_stt_service
+
+
+@dataclass
+class PipelineMetadata:
+    transcript: str
+    stt_language: str
+    stt_confidence: float
+    duration_sec: float
+    intent: str
+    intent_confidence: float
+    intent_source: str
+    slots: dict[str, Any]
+    sentiment_label: str
+    sentiment_score: float
+    entailment_label: str | None
+    entailment_score: float | None
+    response_text: str
+    is_emergency: bool
+    saved_metrics: list[str]
+    notified_family_members: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class VoicePipeline:
+    def __init__(self, db: Session, user: User, source: str = "speaker"):
+        self.db = db
+        self.user = user
+        self.source = source
+        self.stt = get_stt_service()
+        self.nli = get_nli_service()
+        self.llm = LLMClient()
+        self.nlu = NLUService(llm=self.llm)
+        self.health = HealthStatsService(db)
+        self.reporting = ReportingService()
+
+    # ---------- main ----------
+    async def process(self, wav_bytes: bytes) -> tuple[PipelineMetadata, str]:
+        # 1. Сохраняем + STT
+        audio_path, duration = save_wav(self.user.id, wav_bytes)
+        stt: STTResult = await self.stt.transcribe_file(str(audio_path))
+        transcript = stt.text
+
+        if not transcript:
+            meta = self._empty_meta(stt, audio_path, duration)
+            self._persist(meta, audio_path)
+            return meta, "Извините, я не расслышала."
+
+        # 2. NLU и NLI(sentiment) параллельно
+        nlu_task = asyncio.create_task(self.nlu.classify(transcript))
+        sentiment_task = asyncio.create_task(self.nli.sentiment(transcript))
+        nlu_res, sent_res = await asyncio.gather(nlu_task, sentiment_task)
+
+        # 3. Entailment против последнего факта здоровья (если есть)
+        ent_res = await self._maybe_entailment(transcript)
+
+        # 4. Действие по интенту
+        response, saved_metrics, notified = await self._dispatch(nlu_res, transcript, sent_res)
+
+        is_emergency = nlu_res.intent == "panic"
+
+        meta = PipelineMetadata(
+            transcript=transcript,
+            stt_language=stt.language,
+            stt_confidence=stt.confidence,
+            duration_sec=duration,
+            intent=nlu_res.intent,
+            intent_confidence=nlu_res.confidence,
+            intent_source=nlu_res.source,
+            slots=nlu_res.slots,
+            sentiment_label=sent_res.label,
+            sentiment_score=sent_res.score,
+            entailment_label=(ent_res.label if ent_res else None),
+            entailment_score=(ent_res.score if ent_res else None),
+            response_text=response,
+            is_emergency=is_emergency,
+            saved_metrics=saved_metrics,
+            notified_family_members=notified,
+        )
+        self._persist(meta, audio_path)
+        return meta, response
+
+    # ---------- helpers ----------
+    async def _maybe_entailment(self, hypothesis: str) -> EntailmentResult | None:
+        last = (
+            self.db.query(HealthMetric)
+            .filter(HealthMetric.user_id == self.user.id)
+            .order_by(HealthMetric.timestamp.desc())
+            .first()
+        )
+        if not last:
+            return None
+        premise = f"{last.metric_type}: {last.value_json}"
+        return await self.nli.entailment(premise, hypothesis)
+
+    async def _dispatch(
+        self,
+        nlu: NLUResult,
+        text: str,
+        sentiment: SentimentResult,
+    ) -> tuple[str, list[str], int]:
+        saved_metrics: list[str] = []
+        notified = 0
+
+        if nlu.intent == "panic":
+            notified = notify_family_of_emergency(self.db, self.user, message=text)
+            return (
+                "Поняла, отправляю сигнал тревоги вашим близким. Оставайтесь на связи.",
+                saved_metrics,
+                notified,
+            )
+
+        if nlu.intent == "save_metric":
+            metrics = nlu.slots.get("metrics") or []
+            for m in metrics:
+                self.health.add_metric(self.user.id, m["type"], m["value"])
+                saved_metrics.append(m["type"])
+            if saved_metrics:
+                return ("Записала ваши показатели.", saved_metrics, 0)
+            # слотов нет — спросим уточнение
+            return ("Какой показатель вы хотите записать?", saved_metrics, 0)
+
+        if nlu.intent == "get_stats":
+            text_resp = self.reporting.generate_recommendation(self.user.id, self.db)
+            return (text_resp, saved_metrics, 0)
+
+        if nlu.intent == "set_reminder":
+            return ("Напоминание сохранено. Позже вы сможете изменить его в приложении.",
+                    saved_metrics, 0)
+
+        if nlu.intent == "cyclic_query":
+            return ("Хорошо, я буду регулярно спрашивать вас о самочувствии.",
+                    saved_metrics, 0)
+
+        if nlu.intent == "family_invite":
+            return ("Чтобы пригласить родственника, откройте раздел «Семья» в приложении.",
+                    saved_metrics, 0)
+
+        # chitchat / unknown → к LLM с health-контекстом и подсказкой по тону
+        context = self._llm_context(sentiment)
+        prompt = f"Контекст: {context}\n\nСообщение пользователя: {text}\n\nОтвет:"
+        answer = await self.llm.generate_response(prompt)
+        return (answer, saved_metrics, 0)
+
+    def _llm_context(self, sentiment: SentimentResult) -> str:
+        recent = self.health.get_recent_metrics(self.user.id, limit=5)
+        lines = [f"Тон собеседника: {sentiment.label} ({sentiment.score:.2f})."]
+        if recent:
+            lines.append("Последние показатели:")
+            for m in recent:
+                lines.append(f"- {m.metric_type}: {m.value_json} ({m.timestamp:%d.%m %H:%M})")
+        else:
+            lines.append("Нет данных о здоровье.")
+        return "\n".join(lines)
+
+    def _empty_meta(self, stt: STTResult, audio_path, duration: float) -> PipelineMetadata:
+        return PipelineMetadata(
+            transcript="",
+            stt_language=stt.language,
+            stt_confidence=stt.confidence,
+            duration_sec=duration,
+            intent="unknown",
+            intent_confidence=0.0,
+            intent_source="rules",
+            slots={},
+            sentiment_label="neutral",
+            sentiment_score=0.0,
+            entailment_label=None,
+            entailment_score=None,
+            response_text="Извините, я не расслышала.",
+            is_emergency=False,
+            saved_metrics=[],
+            notified_family_members=0,
+        )
+
+    def _persist(self, meta: PipelineMetadata, audio_path) -> None:
+        try:
+            entry = VoiceLog(
+                user_id=self.user.id,
+                audio_path=str(audio_path),
+                duration_sec=meta.duration_sec,
+                transcript=meta.transcript,
+                stt_language=meta.stt_language,
+                stt_confidence=meta.stt_confidence,
+                nlu_intent=meta.intent,
+                nlu_slots=meta.slots,
+                sentiment_label=meta.sentiment_label,
+                sentiment_score=meta.sentiment_score,
+                entailment_label=meta.entailment_label,
+                entailment_score=meta.entailment_score,
+                response_text=meta.response_text,
+                is_emergency=meta.is_emergency,
+                source=self.source,
+            )
+            self.db.add(entry)
+            self.db.commit()
+        except Exception as e:
+            logger.error(f"Не удалось записать VoiceLog: {e}")
+            self.db.rollback()

--- a/migrations/002_voice_pipeline.sql
+++ b/migrations/002_voice_pipeline.sql
@@ -1,0 +1,35 @@
+-- Migration 002: voice pipeline tables (voice_logs + user_settings)
+-- Family/family_members уже описаны в schema1.sql.
+-- Применять идемпотентно: CREATE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS public.voice_logs (
+    id              SERIAL PRIMARY KEY,
+    user_id         INTEGER NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    audio_path      VARCHAR,
+    duration_sec    DOUBLE PRECISION,
+    transcript      TEXT,
+    stt_language    VARCHAR,
+    stt_confidence  DOUBLE PRECISION,
+    nlu_intent      VARCHAR,
+    nlu_slots       JSON,
+    sentiment_label VARCHAR,
+    sentiment_score DOUBLE PRECISION,
+    entailment_label VARCHAR,
+    entailment_score DOUBLE PRECISION,
+    response_text   TEXT,
+    is_emergency    BOOLEAN NOT NULL DEFAULT false,
+    source          VARCHAR,
+    created_at      TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_voice_logs_user_id ON public.voice_logs (user_id);
+CREATE INDEX IF NOT EXISTS ix_voice_logs_intent  ON public.voice_logs (nlu_intent);
+CREATE INDEX IF NOT EXISTS ix_voice_logs_emerg   ON public.voice_logs (is_emergency) WHERE is_emergency = true;
+
+CREATE TABLE IF NOT EXISTS public.user_settings (
+    id            SERIAL PRIMARY KEY,
+    user_id       INTEGER UNIQUE NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    address_name  VARCHAR,
+    voice         VARCHAR NOT NULL DEFAULT 'ru_RU-irina-medium',
+    updated_at    TIMESTAMP WITH TIME ZONE DEFAULT now()
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,12 @@ jinja2
 loguru
 pydantic-settings
 python-dotenv
+
+# Speech / NLP stack
+faster-whisper>=1.0.3        # STT (CTranslate2-backed Whisper)
+piper-tts>=1.2.0             # TTS (neural, streaming)
+soundfile>=0.12.1            # WAV I/O
+transformers>=4.41.0         # NLI / sentiment models (HF)
+torch>=2.2.0                 # backbone for transformers
+sentencepiece>=0.2.0         # tokenizer for ruBERT
+ffmpeg-python>=0.2.0         # audio resample/convert


### PR DESCRIPTION
End-to-end speech processing on the server side per ОПИСАТЕЛЬНОЕ2.docx, so the smart speaker and the mobile app can converse with the assistant.

- STT: faster-whisper (model=small, ru, VAD-фильтр, batch)
- TTS: Piper, ru_RU-irina-medium, чанковый WAV-стрим
- NLU: гибрид regex/keywords + Gemma3-fallback (Ollama format=json) по 7 интентам (save_metric/get_stats/panic/set_reminder/ cyclic_query/family_invite/chitchat)
- NLI: 2 компонента — sentiment (rubert-tiny2-russian-sentiment) и entailment (rubert-base-cased-nli-threeway против последнего факта здоровья).
- Pipeline: STT -> NLU || sentiment (parallel) -> entailment ->
            intent dispatch -> response -> TTS streaming.
- Emergency: при intent=panic рассылается событие всем членам семьи через logs(action='emergency_notify').
- Persist: новая таблица voice_logs хранит аудио-путь, транскрипт, интент, слоты, sentiment/entailment, ответ и emergency-флаг для последующего обучения и аналитики. user_settings — для голоса и имени обращения.
- API (JWT): POST /api/v1/voice/{converse,stt,tts,nlu,nli/sentiment, nli/entailment,emergency}. /converse отдаёт WAV-стрим + метаданные пайплайна в заголовке X-Pipeline-Metadata (base64 JSON).

Audio contract: WAV PCM 16 kHz mono 16-bit (валидация в audio_utils). Конфигурация и пути к моделям вынесены в core/config.py.